### PR TITLE
Use `tox-uv` to use `uv` in test running

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,5 +28,5 @@ jobs:
           pyproject.toml
           requirements.txt
           tox.ini
-    - run: pip install -c requirements.txt tox
+    - run: pip install -c requirements.txt tox tox-uv
     - run: tox -e py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [  # pragma: alphabetize
   "pre-commit",
   "pytest",
   "tox",
+  "tox-uv",
   "uv",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ packaging==24.1
     #   pyproject-api
     #   pytest
     #   tox
+    #   tox-uv
 platformdirs==4.2.2
     # via
     #   tox
@@ -48,9 +49,15 @@ pytest==8.2.2
 pyyaml==6.0.1
     # via pre-commit
 tox==4.16.0
+    # via
+    #   datetime-tools (pyproject.toml)
+    #   tox-uv
+tox-uv==1.9.1
     # via datetime-tools (pyproject.toml)
 uv==0.2.21
-    # via datetime-tools (pyproject.toml)
+    # via
+    #   datetime-tools (pyproject.toml)
+    #   tox-uv
 virtualenv==20.26.3
     # via
     #   pre-commit


### PR DESCRIPTION
- **Replace `nox` with `tox`**
- **Ensure version of `tox` is CI matches pinned version**
- **Use `tox-uv` to use `uv` in test running**
