### PR TITLE
Make `Clock` and `TimezoneConverter` object immutable

### DIFF
--- a/src/datetime_tools/_clock.py
+++ b/src/datetime_tools/_clock.py
@@ -1,14 +1,18 @@
+import dataclasses
 import datetime
 import zoneinfo
 
 from dateutil import relativedelta
 
 
+@dataclasses.dataclass(frozen=True, init=False)
 class Clock:
     """Get the current date/time in a specific timezone."""
 
+    tzinfo: zoneinfo.ZoneInfo
+
     def __init__(self, timezone: str) -> None:
-        self.tzinfo = zoneinfo.ZoneInfo(timezone)
+        object.__setattr__(self, "tzinfo", zoneinfo.ZoneInfo(timezone))
 
     # Current time/date
 

--- a/src/datetime_tools/_converter.py
+++ b/src/datetime_tools/_converter.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime as datetime_
 import zoneinfo
 from typing import Literal
@@ -6,11 +7,14 @@ from dateutil import relativedelta
 from typing_extensions import assert_never
 
 
+@dataclasses.dataclass(frozen=True, init=False)
 class TimezoneConverter:
     """Manage dates and datetimes in a specific timezone."""
 
+    tzinfo: zoneinfo.ZoneInfo
+
     def __init__(self, timezone: str) -> None:
-        self.tzinfo = zoneinfo.ZoneInfo(timezone)
+        object.__setattr__(self, "tzinfo", zoneinfo.ZoneInfo(timezone))
 
     # Constructors
 

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import zoneinfo
 
@@ -7,6 +8,13 @@ import time_machine
 from datetime_tools import Clock
 
 # See Note [Use Europe/Paris for tests]
+
+
+def test_timezone_cannot_be_changed() -> None:
+    clock = Clock("Europe/Paris")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        clock.tzinfo = zoneinfo.ZoneInfo("Europe/London")  # type: ignore[misc]
 
 
 def test_now() -> None:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import zoneinfo
 from typing import Literal
@@ -12,6 +13,13 @@ from datetime_tools import TimezoneConverter
 # localized times cannot be confused with naive times that have had timezone
 # info added. If a naive time is assumed to be in UTC, it will be different
 # when localized to Europe/Paris, regardless of DST.
+
+
+def test_timezone_cannot_be_changed() -> None:
+    paris_time = TimezoneConverter("Europe/Paris")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        paris_time.tzinfo = zoneinfo.ZoneInfo("Europe/London")  # type: ignore[misc]
 
 
 def test_datetime() -> None:


### PR DESCRIPTION
This allows applications to create global singleton instances of these
objects without needing to worry about values being changed.