### PR TITLE
Run all tox environments

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,4 +29,4 @@ jobs:
           requirements.txt
           tox.ini
     - run: pip install -c requirements.txt tox tox-uv
-    - run: tox -e py
+    - run: tox run-parallel --parallel-no-spinner


### PR DESCRIPTION
Before this change, the tests were only being run for Python 3.12. This
ensures we run the tests for all environments.

We run the tests in parallel because it's faster.