### PR TITLE
Run tests on Python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,8 @@ jobs:
           3.10
           3.11
           3.12
+          3.13
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: |
           pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [  # pragma: alphabetize
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Typing :: Typed",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-envlist = py3{10,11,12},report
+envlist = py3{10,11,12,13},report
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.
@@ -19,7 +19,7 @@ commands =
 
 [testenv:report]
 skip_install = true
-depends = py3{10,11,12}
+depends = py3{10,11,12,13}
 commands =
   coverage combine
   coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-envlist = py310,py311,py312,report
+envlist = py3{10,11,12},report
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.
@@ -19,7 +19,7 @@ commands =
 
 [testenv:report]
 skip_install = true
-depends = py310,py311,py312
+depends = py3{10,11,12}
 commands =
   coverage combine
   coverage report


### PR DESCRIPTION
The release candidate for this version is now available, so we should
test against it.