### PR TITLE
Allow date for end and start of month functions

### DIFF
--- a/src/timezone_tools/_converter.py
+++ b/src/timezone_tools/_converter.py
@@ -241,11 +241,12 @@ class TimezoneConverter:
         return self.midnight(self.day_after(when))
 
     def start_of_month(
-        self, datetime: datetime_.datetime
+        self, datetime: datetime_.datetime | datetime_.date
     ) -> datetime_.datetime:
         """Find the moment of the start of this month in this timezone.
 
         This will be midnight on the first day of the month.
+        Although the argument is called 'datetime', it can also be a date.
 
         Raises:
             NaiveDatetime: The datetime is naive, so we do not know which
@@ -254,10 +255,13 @@ class TimezoneConverter:
         """
         return self.midnight(self.first_day_of_month(datetime))
 
-    def end_of_month(self, datetime: datetime_.datetime) -> datetime_.datetime:
+    def end_of_month(
+            self, datetime: datetime_.datetime | datetime_.date
+    ) -> datetime_.datetime:
         """Find the moment of the end of this month in this timezone.
 
         This will be midnight on the first day of the following month.
+        Although the argument is called 'datetime', it can also be a date.
 
         Raises:
             NaiveDatetime: The datetime is naive, so we do not know which
@@ -269,7 +273,7 @@ class TimezoneConverter:
         )
 
     def first_day_of_month(
-        self, datetime: datetime_.datetime
+        self, datetime: datetime_.datetime | datetime_.date
     ) -> datetime_.date:
         """Find the date of the first day of this month in this timezone.
 
@@ -278,10 +282,11 @@ class TimezoneConverter:
                 timezone to localize from. Use `make_aware` to make a naive
                 datetime timezone-aware.
         """
+        datetime = self.midnight(datetime)
         return self.date(datetime).replace(day=1)
 
     def last_day_of_month(
-        self, datetime: datetime_.datetime
+        self, datetime: datetime_.datetime | datetime_.date
     ) -> datetime_.date:
         """Find the date of the last day of this month in this timezone.
 

--- a/src/timezone_tools/_converter.py
+++ b/src/timezone_tools/_converter.py
@@ -256,7 +256,7 @@ class TimezoneConverter:
         return self.midnight(self.first_day_of_month(datetime))
 
     def end_of_month(
-            self, datetime: datetime_.datetime | datetime_.date
+        self, datetime: datetime_.datetime | datetime_.date
     ) -> datetime_.datetime:
         """Find the moment of the end of this month in this timezone.
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -526,18 +526,22 @@ def test_next_midnight_requires_aware_datetime() -> None:
             datetime.datetime(
                 2024, 7, 9, 12, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
             ),
-            id="same timezone",
+            id="datetime, same timezone",
         ),
         pytest.param(
             # June in London; July in Paris
             datetime.datetime(
                 2024, 6, 30, 23, 30, tzinfo=zoneinfo.ZoneInfo("Europe/London")
             ),
-            id="different timezone",
+            id="datetime, different timezone",
+        ),
+        pytest.param(
+            datetime.date(2024, 7, 9),
+            id="date",
         ),
     ),
 )
-def test_start_of_month(when: datetime.datetime) -> None:
+def test_start_of_month(when: datetime.datetime | datetime.date) -> None:
     paris_time = TimezoneConverter("Europe/Paris")
 
     assert paris_time.start_of_month(when) == datetime.datetime(
@@ -561,18 +565,22 @@ def test_start_of_month_requires_aware_datetime() -> None:
             datetime.datetime(
                 2024, 7, 9, 12, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
             ),
-            id="same timezone",
+            id="datetime, same timezone",
         ),
         pytest.param(
             # June in London; July in Paris
             datetime.datetime(
                 2024, 6, 30, 23, 30, tzinfo=zoneinfo.ZoneInfo("Europe/London")
             ),
-            id="different timezone",
+            id="datetime, different timezone",
+        ),
+        pytest.param(
+            datetime.date(2024, 7, 9),
+            id="date",
         ),
     ),
 )
-def test_end_of_month(when: datetime.datetime) -> None:
+def test_end_of_month(when: datetime.datetime | datetime.date) -> None:
     paris_time = TimezoneConverter("Europe/Paris")
 
     assert paris_time.end_of_month(when) == datetime.datetime(
@@ -596,18 +604,22 @@ def test_end_of_month_requires_aware_datetime() -> None:
             datetime.datetime(
                 2024, 7, 9, 12, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
             ),
-            id="same timezone",
+            id="datetime, same timezone",
         ),
         pytest.param(
             # June in London; July in Paris
             datetime.datetime(
                 2024, 6, 30, 23, 30, tzinfo=zoneinfo.ZoneInfo("Europe/London")
             ),
-            id="different timezone",
+            id="datetime, different timezone",
+        ),
+        pytest.param(
+            datetime.date(2024, 7, 9),
+            id="date",
         ),
     ),
 )
-def test_first_day_of_month(when: datetime.datetime) -> None:
+def test_first_day_of_month(when: datetime.datetime | datetime.date) -> None:
     paris_time = TimezoneConverter("Europe/Paris")
 
     assert paris_time.first_day_of_month(when) == datetime.date(2024, 7, 1)
@@ -629,18 +641,22 @@ def test_first_day_of_month_requires_aware_datetime() -> None:
             datetime.datetime(
                 2024, 7, 9, 12, 45, tzinfo=zoneinfo.ZoneInfo("Europe/Paris")
             ),
-            id="same timezone",
+            id="datetime, same timezone",
         ),
         pytest.param(
             # June in London; July in Paris
             datetime.datetime(
                 2024, 6, 30, 23, 30, tzinfo=zoneinfo.ZoneInfo("Europe/London")
             ),
-            id="different timezone",
+            id="datetime, different timezone",
+        ),
+        pytest.param(
+            datetime.date(2024, 7, 9),
+            id="date,",
         ),
     ),
 )
-def test_last_day_of_month(when: datetime.datetime) -> None:
+def test_last_day_of_month(when: datetime.datetime | datetime.date) -> None:
     paris_time = TimezoneConverter("Europe/Paris")
 
     assert paris_time.last_day_of_month(when) == datetime.date(2024, 7, 31)


### PR DESCRIPTION
This PR aims to make the methods related to the beginning and end of months more flexible by also accepting `datetime.date` additionally to `datetime.datetime` as input.