### PR TITLE
Update all test dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  groups:
+    testing-dependencies:
+      patterns:
+        - "*"  # group all updates


### PR DESCRIPTION
We don't need to upgrade these separately because we are not deploying
this as an application in which we could have incidents. These pinned
versions are only used for testing: if they cause test failures the PR
will not be merged.
