### PR TITLE
v0.1.0+post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.0+post1] - 2025-05-02
+
+This release updates the package metadata to reflect:
+
+- the new repository location in the `kraken-tech` GitHub org;
+- compatibility with Python 3.13;
+- the license as specified by a SPDX license classifier.
+
 ## [0.1.0] - 2024-07-11
 
 The first release of this package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ where = ["src"]
 
 [project]
 name = "timezone_tools"
-version = "0.1.0"
+version = "0.1.0+post1"
 description = "Tools for working with timezone-aware datetimes."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
This version does not change anything about the library, only its
package metadata. As such, a bump to the version number is not required.
