### PR TITLE
Use correct form for version `0.1.0.post1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.1.0+post1] - 2025-05-02
+## [0.1.0.post1] - 2025-05-02
 
 This release updates the package metadata to reflect:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ where = ["src"]
 
 [project]
 name = "timezone_tools"
-version = "0.1.0+post1"
+version = "0.1.0.post1"
 description = "Tools for working with timezone-aware datetimes."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
PyPI considers versions containing a `+` character
to be "local" versions and will not publish them.
The PyPI specification for public version numbers
(https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers)
requires post-release versions to be suffixed with `.postN`.

This change ensures we follow that specification.

---

I incorrectly used the specification from <https://semver.org> when I made this change initially.